### PR TITLE
Corrected hook arguments to use the correct ID

### DIFF
--- a/lua/wmcp/cl_ui.lua
+++ b/lua/wmcp/cl_ui.lua
@@ -157,11 +157,11 @@ function wmcp.CreateMediaList(par)
 		end):SetImage("icon16/monitor_delete.png")
 
 		-- Parameters:
-		--   menu  - a DMenu
-		--   id    - the row ID
-		--   line  - a DListView_Line (see the function ModLine)
-		--   media - a table with the following keys: title, url, a_sid, a_nick
-		hook.Call("WMCPMedialistRowRightClick", nil, menu, id, line, t[id])
+		--   menu    - a DMenu
+		--   mediaId - the line's media ID
+		--   line    - a DListView_Line (see the function ModLine)
+		--   media   - a table with the following keys: title, url, a_sid, a_nick
+		hook.Call("WMCPMedialistRowRightClick", nil, menu, line.MediaId, line, t[line.MediaId])
 
 		menu:Open()
 	end


### PR DESCRIPTION
Here's a corrected example of usage

```
hook.Add("WMCPMedialistRowRightClick", "WMCPAddDebugItem", function(menu, mediaId, line, media)
    menu:AddSpacer()

    menu:AddOption("Print data", function()
        print("Printing debug data from WMCP")
        print("menu: ", menu)
        print("mediaId: ", mediaId)
        print("line:", line)
        print("media:")
        PrintTable(media or {}, 1)
        print("")
    end):SetImage("icon16/lightning.png")
end)
```
