### PR TITLE
Add options for muting when the game is unfocused

### DIFF
--- a/lua/wmcp/cl_media.lua
+++ b/lua/wmcp/cl_media.lua
@@ -100,6 +100,7 @@ end)
 
 -- if not 0 then music is muted when GMOD's window isn't focused.
 local wmcp_muteifunfocused = CreateConVar("wmcp_muteifunfocused", "0", FCVAR_ARCHIVE)
+local snd_mute_losefocus = GetConVar("snd_mute_losefocus")
 
 -- Non-Windows operating systems don't have a correct system.HasFocus() :|
 if system.IsWindows() then
@@ -116,11 +117,9 @@ if system.IsWindows() then
 			if clip:getVolume() ~= wmcpVolume then
 				clip:setVolume(wmcpVolume)
 			end
-		else
-			if wmcp_muteifunfocused:GetBool() then
-				if clip:getVolume() ~= 0 then
-					clip:setVolume(0)
-				end
+		elseif snd_mute_losefocus:GetBool() or wmcp_muteifunfocused:GetBool() then
+			if clip:getVolume() ~= 0 then
+				clip:setVolume(0)
 			end
 		end
 	end

--- a/lua/wmcp/cl_media.lua
+++ b/lua/wmcp/cl_media.lua
@@ -98,9 +98,9 @@ concommand.Add("wmcp_stop", function()
 	wmcp.StopClip()
 end)
 
--- if not 0 then music is muted when GMOD's window isn't focused.
-local wmcp_muteifunfocused = CreateConVar("wmcp_muteifunfocused", "0", FCVAR_ARCHIVE)
 local snd_mute_losefocus = GetConVar("snd_mute_losefocus")
+local wmcp_unfocusedmute = CreateConVar("wmcp_unfocusedmute", "2", FCVAR_ARCHIVE,
+	"0=Don't mute, 1=Mute, 2=Mute if snd_mute_losefocus")
 
 -- Non-Windows operating systems don't have a correct system.HasFocus() :|
 if system.IsWindows() then
@@ -117,8 +117,19 @@ if system.IsWindows() then
 			if clip:getVolume() ~= wmcpVolume then
 				clip:setVolume(wmcpVolume)
 			end
-		elseif snd_mute_losefocus:GetBool() or wmcp_muteifunfocused:GetBool() then
-			if clip:getVolume() ~= 0 then
+		else
+			local muteStyle = math.Clamp(wmcp_unfocusedmute:GetInt(), 0, 2)
+			local shouldMute = false
+
+			-- don't need to handle case of muteStyle being 0
+
+			if muteStyle == 1 then -- mute
+				shouldMute = true
+			elseif muteStyle == 2 then -- mute if snd_mute_losefocus
+				shouldMute = snd_mute_losefocus:GetBool()
+			end
+
+			if shouldMute and clip:getVolume() ~= 0 then
 				clip:setVolume(0)
 			end
 		end

--- a/lua/wmcp/cl_media.lua
+++ b/lua/wmcp/cl_media.lua
@@ -60,12 +60,13 @@ function wmcp.GetVolume()
 end
 
 function wmcp.SetVolume(vol)
-	-- ConVar:SetFloat will be available next update (current date: feb 2nd 2016)
-	--wmcp_volume:SetFloat(vol)
-	RunConsoleCommand("wmcp_volume", tostring(vol))
+	wmcp_volume:SetFloat(vol)
 
 	local clip = wmcp.Clip
-	if IsValid(clip) then clip:setVolume(vol) end
+
+	if IsValid(clip) then
+		clip:setVolume(vol)
+	end
 end
 
 function wmcp.StopClip()


### PR DESCRIPTION
This won't do anything on Linux or OS X clients as `system.HasFocus()` doesn't work correctly for them.

The default value is `0` so people don't have to change the ConVar to retain the current behavior of not muting.
