### PR TITLE
Stop nettable from sending unneeded changes

### DIFF
--- a/lua/wmcp/cl_ui.lua
+++ b/lua/wmcp/cl_ui.lua
@@ -220,7 +220,17 @@ function wmcp.CreateMediaList(par)
 			for _,line in pairs(medialist.Lines) do
 				if line.MediaId == id then
 					local lineid = line:GetID()
-					if lineid then medialist:RemoveLine(lineid) end
+
+					if lineid then
+						medialist:RemoveLine(lineid)
+
+						-- Unselecting lines because it would be confusing to
+						--  see the line you just deleted to still be selected.
+						for k,v in pairs(medialist.Lines) do
+							v:SetSelected(false)
+						end
+					end
+
 					break
 				end
 			end

--- a/lua/wmcp/sv_medialist.lua
+++ b/lua/wmcp/sv_medialist.lua
@@ -14,7 +14,7 @@ else
 	Add("Right click a line to access its options", "https://www.youtube.com/watch?v=ljTYQ5ZZj7E")
 	Add("You can remove these songs by right clicking and selecting 'Delete'", "https://www.youtube.com/watch?v=X7yiV6226Xg")
 
-	nettable.commit(t)	
+	nettable.commit(t)
 end
 
 function wmcp.Persist()
@@ -63,6 +63,7 @@ concommand.Add("wmcp_add", function(ply, cmd, args, raw)
 		wmcp.Persist()
 	end)
 end)
+
 concommand.Add("wmcp_settitle", function(ply, cmd, args, raw)
 	if not wmcp.IsAllowed(ply, "edit") then ply:ChatPrint("access denied") return end
 
@@ -96,11 +97,22 @@ concommand.Add("wmcp_play", function(ply, cmd, args, raw)
 		net.Broadcast()
 	end)
 end)
+
 concommand.Add("wmcp_del", function(ply, cmd, args, raw)
 	if not wmcp.IsAllowed(ply, "del") then ply:ChatPrint("access denied") return end
 
 	local id = tonumber(args[1])
-	if id then table.remove(t, id) end
+
+	if not id or not t[id] then
+		return -- should an error be given?
+	end
+
+	if #t > 1 then
+		t[id] = t[#t] -- replace the to-be-deleted line with the last line
+		t[#t] = nil -- remove the last line
+	else
+		table.remove(t, id)
+	end
 
 	nettable.commit(t)
 	wmcp.Persist()


### PR DESCRIPTION
If a line is deleted the server uses `table.remove(t, id)` to remove the line from the table. If `id` is less than `#t` though, this will cause every value from `id` to `#t` to be moved down an index which _nettable_ will interpret as modifications for lines `id` through `#t`.

These changes replace the to-be-deleted line with the last line and then removes the last line. Now it's 1-2 modifications sent opposed to `#t - id + 1` modifications.

Also when a line is deleted all lines are deselected because

```
-- Unselecting lines because it would be confusing to
--  see the line you just deleted to still be selected.
```
