### PR TITLE
implement clip:stop() changes

### DIFF
--- a/lua/wmcp/cl_media.lua
+++ b/lua/wmcp/cl_media.lua
@@ -1,5 +1,7 @@
 function wmcp.Play(url, overridingMeta)
-	if IsValid(wmcp.Clip) then wmcp.Clip:stop() end
+	if IsValid(wmcp.Clip) then
+		wmcp.Clip:stop()
+	end
 
 	local service = medialib.load("media").guessService(url)
 	local clip = service:load(url)
@@ -73,12 +75,6 @@ function wmcp.StopClip()
 	local clip = wmcp.Clip
 
 	if IsValid(clip) then
-		-- Hacky way to stop anything from happening on clip end.
-		-- For example, if a song is started from the GUI, on clip end
-		-- the next song on the GUI list will play.
-		if clip._events then
-			clip._events["ended"] = nil
-		end
 		clip:stop()
 	end
 

--- a/lua/wmcp/cl_ui.lua
+++ b/lua/wmcp/cl_ui.lua
@@ -113,8 +113,12 @@ function wmcp.CreateMediaList(par)
 
 		local clip = wmcp.Play(e.url, {title = e.title})
 		if clip then
-			clip:on("ended", function()
-				timer.Simple(0.5, function() Play(mid+1) end)
+			clip:on("ended", function(info)
+				if not info or not info.stopped then
+					timer.Simple(0.5, function()
+						Play(mid+1)
+					end)
+				end
 			end)
 		end
 	end


### PR DESCRIPTION
**This shouldn't be merged unless [this](https://github.com/wyozi/gmod-medialib/pull/53) is merged.**

This fixes a bug of the wrong media being played when a media-line is double-clicked while media is already playing.
